### PR TITLE
feat: use large image for album cover in discord rpc

### DIFF
--- a/src/Receivers/dc-rpc.ts
+++ b/src/Receivers/dc-rpc.ts
@@ -19,15 +19,15 @@ export const DCRPC = {
 ClientID=1101918033640951941
 
 [State]
-State=${name}
-Details=${artist}
+State=${artist}
+Details=${name}
 StartTimestamp=${Date.now()}
 
 [Images]
-LargeImage=bncm
-LargeImageTooltip=
-SmallImage=${cover}
-SmallImageTooltip=${name}
+LargeImage=${cover}
+LargeImageTooltip=${name}
+SmallImage=bncm
+SmallImageTooltip=BetterNCM
 `
     },
     async update({ songName, authorName, thumbnail }) {


### PR DESCRIPTION
调整Discord RPC样式

调整前
![{EA0AEAA1-F5C8-4FFF-97DC-9EE269F2CAD7}](https://github.com/user-attachments/assets/2c804dc1-4666-4e45-8a91-cbf5a2dc6ffc)
调整后
![{C0A41D92-AEE5-4214-AEE1-20464DA0A7E6}](https://github.com/user-attachments/assets/a9cd0a83-db41-43c8-a919-b84c19f523f9)

不知道为什么logo在小图标上显示不出来，可能需要在[Developer Portal](https://discord.com/developers/applications)上重新上传一下